### PR TITLE
feat: add function to detect qos

### DIFF
--- a/rqt_image_overlay/CMakeLists.txt
+++ b/rqt_image_overlay/CMakeLists.txt
@@ -26,7 +26,8 @@ set(SOURCES
   src/overlay_manager.cpp
   src/overlay.cpp
   src/image_manager.cpp
-  src/list_image_topics.cpp)
+  src/list_image_topics.cpp
+  src/try_discover_source.cpp)
 qt5_wrap_cpp(SOURCES    # Must do this for qt's Meta-Object Compiler.
   src/image_overlay.hpp
   src/composition_frame.hpp

--- a/rqt_image_overlay/src/overlay.hpp
+++ b/rqt_image_overlay/src/overlay.hpp
@@ -16,6 +16,7 @@
 #define OVERLAY_HPP_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include "pluginlib/class_loader.hpp"
 
@@ -24,6 +25,7 @@ namespace rclcpp
 {
 class Node;
 class GenericSubscription;
+class QoS;
 class SerializedMessage;
 class Time;
 }

--- a/rqt_image_overlay/src/try_discover_source.cpp
+++ b/rqt_image_overlay/src/try_discover_source.cpp
@@ -1,0 +1,95 @@
+// Copyright 2022 Daisuke Nishimatsu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "try_discover_source.hpp"
+
+namespace rqt_image_overlay
+{
+std::optional<std::pair<std::string, rclcpp::QoS>> tryDiscoverSource(
+  const std::shared_ptr<rclcpp::Node> & node, const std::string & topic)
+{
+  // borrowed this from domain bridge
+  // (https://github.com/ros2/domain_bridge/blob/main/src/domain_bridge/wait_for_graph_events.hpp)
+  // Query QoS info for publishers
+  std::vector<rclcpp::TopicEndpointInfo> endpoint_info_vec =
+    node->get_publishers_info_by_topic(topic);
+  std::size_t num_endpoints = endpoint_info_vec.size();
+
+  // If there are no publishers, return an empty optional
+  if (num_endpoints < 1u) {
+    return {};
+  }
+
+  // Initialize QoS
+  rclcpp::QoS qos{10};
+  // Default reliability and durability to value of first endpoint
+  qos.reliability(endpoint_info_vec[0].qos_profile().reliability());
+  qos.durability(endpoint_info_vec[0].qos_profile().durability());
+  // Always use automatic liveliness
+  qos.liveliness(rclcpp::LivelinessPolicy::Automatic);
+
+  // Reliability and durability policies can cause trouble with enpoint matching
+  // Count number of "reliable" publishers and number of "transient local" publishers
+  std::size_t reliable_count = 0u;
+  std::size_t transient_local_count = 0u;
+  // For duration-based policies, note the largest value to ensure matching all publishers
+  rclcpp::Duration max_deadline(0, 0u);
+  rclcpp::Duration max_lifespan(0, 0u);
+  for (const auto & info : endpoint_info_vec) {
+    const auto & profile = info.qos_profile();
+    if (profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) {
+      reliable_count++;
+    }
+    if (profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
+      transient_local_count++;
+    }
+    if (profile.deadline() > max_deadline) {
+      max_deadline = profile.deadline();
+    }
+    if (profile.lifespan() > max_lifespan) {
+      max_lifespan = profile.lifespan();
+    }
+  }
+
+  // If not all publishers have a "reliable" policy, then use a "best effort" policy
+  // and print a warning
+  if (reliable_count > 0u && reliable_count != num_endpoints) {
+    qos.best_effort();
+    RCLCPP_WARN(
+      node->get_logger(), "Some, but not all, publishers on topic %s "
+      "offer 'reliable' reliability. Falling back to 'best effort' reliability in order"
+      "to connect to all publishers.", topic.c_str());
+  }
+
+  // If not all publishers have a "transient local" policy, then use a "volatile" policy
+  // and print a warning
+  if (transient_local_count > 0u && transient_local_count != num_endpoints) {
+    qos.durability_volatile();
+    RCLCPP_WARN(
+      node->get_logger(), "Some, but not all, publishers on topic %s "
+      "offer 'transient local' durability. Falling back to 'volatile' durability in order"
+      "to connect to all publishers.", topic.c_str());
+  }
+
+  qos.deadline(max_deadline);
+  qos.lifespan(max_lifespan);
+
+  if (!endpoint_info_vec.empty()) {
+    return std::make_pair(endpoint_info_vec[0].topic_type(), qos);
+  } else {
+    return {};
+  }
+}
+}  // namespace rqt_image_overlay

--- a/rqt_image_overlay/src/try_discover_source.hpp
+++ b/rqt_image_overlay/src/try_discover_source.hpp
@@ -1,0 +1,31 @@
+// Copyright 2022 Daisuke Nishimatsu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRY_DISCOVER_SOURCE_HPP_
+#define TRY_DISCOVER_SOURCE_HPP_
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace rqt_image_overlay
+{
+std::optional<std::pair<std::string, rclcpp::QoS>> tryDiscoverSource(
+  const std::shared_ptr<rclcpp::Node> & node, const std::string & topic);
+}  // namespace rqt_image_overlay
+
+#endif  // TRY_DISCOVER_SOURCE_HPP_


### PR DESCRIPTION
This feature enables to detect qos of image and overlays automatically, so 
the image which has best effort qos can be shown in the viewer.
```
❯ ros2 topic info -v /image_raw

Type: sensor_msgs/msg/Image

Publisher count: 1

Node name: usb_cam
Node namespace: /
Topic type: sensor_msgs/msg/Image
Endpoint type: PUBLISHER
GID: 03.49.10.01.14.53.a4.f5.3f.dc.00.77.00.00.17.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: BEST_EFFORT
  Durability: VOLATILE
  Lifespan: 9223372036854775807 nanoseconds
  Deadline: 9223372036854775807 nanoseconds
  Liveliness: AUTOMATIC
  Liveliness lease duration: 9223372036854775807 nanoseconds

Subscription count: 1

Node name: rqt_gui_cpp_node_71541
Node namespace: /
Topic type: sensor_msgs/msg/Image
Endpoint type: SUBSCRIPTION
GID: 96.46.10.01.1c.5e.c3.d1.5b.c2.d0.c9.00.00.16.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: BEST_EFFORT
  Durability: VOLATILE
  Lifespan: 9223372036854775807 nanoseconds
  Deadline: 9223372036854775807 nanoseconds
  Liveliness: AUTOMATIC
  Liveliness lease duration: 9223372036854775807 nanoseconds
```