### PR TITLE
Use rqt_image_overlay::ImageTopic to store Image Topic and Transport

### DIFF
--- a/rqt_image_overlay/src/image_manager.cpp
+++ b/rqt_image_overlay/src/image_manager.cpp
@@ -33,26 +33,23 @@ void ImageManager::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr &
 }
 
 
-void ImageManager::onTopicChanged(const QString & text)
+void ImageManager::onTopicChanged(int index)
 {
   subscriber.shutdown();
 
   // reset image on topic change
   std::atomic_store(&lastMsg, sensor_msgs::msg::Image::ConstSharedPtr{});
 
-  QStringList parts = text.split(" ");
-  QString topic = parts.first();
-  QString transport = parts.length() == 2 ? parts.last() : "raw";
-
-  if (!topic.isEmpty()) {
+  if (index > 0) {
+    ImageTopic & imageTopic = imageTopics.at(index - 1);
     try {
       subscriber = image_transport::create_subscription(
-        node.get(), topic.toStdString(),
+        node.get(), imageTopic.topic,
         std::bind(&ImageManager::callbackImage, this, std::placeholders::_1),
-        transport.toStdString(), rmw_qos_profile_sensor_data);
+        imageTopic.transport, rmw_qos_profile_sensor_data);
       qDebug(
         "ImageView::onTopicChanged() to topic '%s' with transport '%s'",
-        topic.toStdString().c_str(), subscriber.getTransport().c_str());
+        imageTopic.topic.c_str(), imageTopic.transport.c_str());
     } catch (image_transport::TransportLoadException & e) {
       qWarning("(ImageManager) Loading image transport plugin failed");
     }
@@ -62,21 +59,18 @@ void ImageManager::onTopicChanged(const QString & text)
 void ImageManager::updateImageTopicList()
 {
   beginResetModel();
-  topics.clear();
+  imageTopics.clear();
 
   // fill combo box
-  topics = ListImageTopics(*node);
+  imageTopics = ListImageTopics(*node);
 
-  for (std::string & topic : topics) {
-    std::replace(topic.begin(), topic.end(), ' ', '/');
-  }
   endResetModel();
 }
 
 
 int ImageManager::rowCount(const QModelIndex &) const
 {
-  return topics.size() + 1;
+  return imageTopics.size() + 1;
 }
 
 QVariant ImageManager::data(const QModelIndex & index, int role) const
@@ -85,8 +79,8 @@ QVariant ImageManager::data(const QModelIndex & index, int role) const
     if (index.row() == 0) {
       return QVariant();
     } else {
-      std::string topic = topics.at(index.row() - 1);
-      return QString::fromStdString(topic);
+      const ImageTopic & imageTopic = imageTopics.at(index.row() - 1);
+      return QString::fromStdString(imageTopic.toString());
     }
   }
 
@@ -105,11 +99,20 @@ std::shared_ptr<QImage> ImageManager::getImage() const
   return image;
 }
 
-void ImageManager::setTopicExplicitly(QString topic)
+std::optional<ImageTopic> ImageManager::getImageTopic(unsigned index)
+{
+  if (index > 0 && index < imageTopics.size()) {
+    const ImageTopic & it = imageTopics.at(index);
+    return std::make_optional<ImageTopic>(it);
+  }
+  return std::nullopt;
+}
+
+void ImageManager::addImageTopicExplicitly(ImageTopic imageTopic)
 {
   beginResetModel();
-  topics.clear();
-  topics.push_back(topic.toStdString());
+  imageTopics.clear();
+  imageTopics.push_back(imageTopic);
   endResetModel();
 }
 

--- a/rqt_image_overlay/src/image_manager.hpp
+++ b/rqt_image_overlay/src/image_manager.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include "image_transport/subscriber.hpp"
+#include "image_topic.hpp"
 
 namespace rclcpp {class Node;}
 
@@ -34,14 +35,15 @@ class ImageManager : public QAbstractListModel
 public:
   explicit ImageManager(const std::shared_ptr<rclcpp::Node> & node);
   std::shared_ptr<QImage> getImage() const;
-  void setTopicExplicitly(QString topic);
+  std::optional<ImageTopic> getImageTopic(unsigned index);
+  void addImageTopicExplicitly(ImageTopic imageTopic);
 
 protected:
   int rowCount(const QModelIndex & parent = QModelIndex()) const override;
   QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
 
 public slots:
-  void onTopicChanged(const QString & text);
+  void onTopicChanged(int index);
   void updateImageTopicList();
 
 private:
@@ -51,7 +53,7 @@ private:
   const std::shared_ptr<rclcpp::Node> & node;
   sensor_msgs::msg::Image::ConstSharedPtr lastMsg;
 
-  std::vector<std::string> topics;
+  std::vector<ImageTopic> imageTopics;
 };
 
 }  // namespace rqt_image_overlay

--- a/rqt_image_overlay/src/image_topic.hpp
+++ b/rqt_image_overlay/src/image_topic.hpp
@@ -1,0 +1,58 @@
+// Copyright 2022 Kenji Brameld
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMAGE_TOPIC_HPP_
+#define IMAGE_TOPIC_HPP_
+
+#include <string>
+
+namespace rqt_image_overlay
+{
+
+class ImageTopic
+{
+public:
+  ImageTopic(const std::string topic, const std::string transport)
+  : topic(topic), transport(transport) {}
+
+  ImageTopic(const ImageTopic & other)
+  : topic(other.topic), transport(other.transport) {}
+
+  const std::string topic;
+  const std::string transport;
+
+  bool operator==(const ImageTopic & other) const
+  {
+    return (topic == other.topic) && (transport == other.transport);
+  }
+
+  bool operator!=(const ImageTopic & other) const
+  {
+    return (topic != other.topic) || (transport != other.transport);
+  }
+
+  std::string toString() const
+  {
+    return topic + " (" + transport + ")";
+  }
+};
+
+inline std::ostream & operator<<(std::ostream & strm, const ImageTopic & imageTopic)
+{
+  return strm << imageTopic.toString();
+}
+
+}  // namespace rqt_image_overlay
+
+#endif  // IMAGE_TOPIC_HPP_

--- a/rqt_image_overlay/src/list_image_topics.cpp
+++ b/rqt_image_overlay/src/list_image_topics.cpp
@@ -21,17 +21,17 @@
 namespace rqt_image_overlay
 {
 
-std::vector<std::string> ListImageTopics(const rclcpp::Node & node)
+std::vector<ImageTopic> ListImageTopics(const rclcpp::Node & node)
 {
-  std::map<std::string, std::vector<std::string>> topic_info = node.get_topic_names_and_types();
+  std::map<std::string, std::vector<std::string>> topicInfo = node.get_topic_names_and_types();
 
-  std::vector<std::string> topics;
-  for (auto const & [topic_name, topic_types] : topic_info) {
-    if (std::count(topic_types.begin(), topic_types.end(), "sensor_msgs/msg/Image") > 0) {
-      topics.push_back(topic_name);
+  std::vector<ImageTopic> imageTopics;
+  for (auto const & [topicName, topicTypes] : topicInfo) {
+    if (std::count(topicTypes.begin(), topicTypes.end(), "sensor_msgs/msg/Image") > 0) {
+      imageTopics.push_back({topicName, "raw"});
     }
   }
-  return topics;
+  return imageTopics;
 }
 
 }  // namespace rqt_image_overlay

--- a/rqt_image_overlay/src/list_image_topics.hpp
+++ b/rqt_image_overlay/src/list_image_topics.hpp
@@ -16,7 +16,7 @@
 #define LIST_IMAGE_TOPICS_HPP_
 
 #include <vector>
-#include <string>
+#include "image_topic.hpp"
 
 // forward declaration
 namespace rclcpp {class Node;}
@@ -24,7 +24,7 @@ namespace rclcpp {class Node;}
 namespace rqt_image_overlay
 {
 
-std::vector<std::string> ListImageTopics(const rclcpp::Node & node);
+std::vector<ImageTopic> ListImageTopics(const rclcpp::Node & node);
 
 }  // namespace rqt_image_overlay
 

--- a/rqt_image_overlay/test/test_list_image_topics.cpp
+++ b/rqt_image_overlay/test/test_list_image_topics.cpp
@@ -49,7 +49,7 @@ TEST_F(TestListImageTopics, TestOne)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
 
-  auto publisher = image_transport::create_publisher(node.get(), "test_topic");
+  auto publisher = image_transport::create_publisher(node.get(), "/test_topic");
 
   // Give a chance for the topic to be picked up
   rclcpp::sleep_for(std::chrono::milliseconds(10));
@@ -57,16 +57,19 @@ TEST_F(TestListImageTopics, TestOne)
 
   auto topics = rqt_image_overlay::ListImageTopics(*node);
   ASSERT_EQ(topics.size(), 1u);
-  EXPECT_EQ(topics.at(0), "/test_topic");
+  EXPECT_EQ(
+    std::count(
+      topics.begin(), topics.end(),
+      rqt_image_overlay::ImageTopic{"/test_topic", "raw"}), 1);
 }
 
 TEST_F(TestListImageTopics, TestThree)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
 
-  auto publisher1 = image_transport::create_publisher(node.get(), "test_ns1/test_topic1");
-  auto publisher2 = image_transport::create_publisher(node.get(), "test_ns2/test_topic2");
-  auto publisher3 = image_transport::create_publisher(node.get(), "test_ns3/test_topic3");
+  auto publisher1 = image_transport::create_publisher(node.get(), "/test_ns1/test_topic1");
+  auto publisher2 = image_transport::create_publisher(node.get(), "/test_ns2/test_topic2");
+  auto publisher3 = image_transport::create_publisher(node.get(), "/test_ns3/test_topic3");
 
   // Give a chance for the topic to be picked up
   rclcpp::sleep_for(std::chrono::milliseconds(10));
@@ -74,7 +77,16 @@ TEST_F(TestListImageTopics, TestThree)
 
   auto topics = rqt_image_overlay::ListImageTopics(*node);
   ASSERT_EQ(topics.size(), 3u);
-  EXPECT_EQ(std::count(topics.begin(), topics.end(), "/test_ns1/test_topic1"), 1);
-  EXPECT_EQ(std::count(topics.begin(), topics.end(), "/test_ns2/test_topic2"), 1);
-  EXPECT_EQ(std::count(topics.begin(), topics.end(), "/test_ns3/test_topic3"), 1);
+  EXPECT_EQ(
+    std::count(
+      topics.begin(), topics.end(),
+      rqt_image_overlay::ImageTopic{"/test_ns1/test_topic1", "raw"}), 1);
+  EXPECT_EQ(
+    std::count(
+      topics.begin(), topics.end(),
+      rqt_image_overlay::ImageTopic{"/test_ns2/test_topic2", "raw"}), 1);
+  EXPECT_EQ(
+    std::count(
+      topics.begin(), topics.end(),
+      rqt_image_overlay::ImageTopic{"/test_ns3/test_topic3", "raw"}), 1);
 }


### PR DESCRIPTION
convert type used to store image topic from std::string to rqt_image_overlay::ImageTopic

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>