### PR TITLE
Handle fake transports that end with a transport ending

### DIFF
--- a/rqt_image_overlay/src/list_image_topics.hpp
+++ b/rqt_image_overlay/src/list_image_topics.hpp
@@ -24,7 +24,7 @@ namespace rclcpp {class Node;}
 namespace rqt_image_overlay
 {
 
-std::vector<ImageTopic> ListImageTopics(const rclcpp::Node & node);
+std::vector<ImageTopic> ListImageTopics(rclcpp::Node & node);
 
 }  // namespace rqt_image_overlay
 

--- a/rqt_image_overlay/test/test_list_image_topics.cpp
+++ b/rqt_image_overlay/test/test_list_image_topics.cpp
@@ -113,3 +113,20 @@ TEST_F(TestListImageTopics, TestThree)
       imageTopics,
       rqt_image_overlay::ImageTopic{"/test_ns3/test_topic3", "theora"}));
 }
+
+TEST_F(TestListImageTopics, TestFakeTheoraTransport)
+{
+  // In this example, we test a case where the topic name ends with a transport type, but the msg
+  // type is not theora_image_transport::msg::Packet.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+
+  auto publisher =
+    node->create_publisher<std_msgs::msg::String>("/test_topic/theora", 1);
+
+  // Give a chance for the topic to be picked up
+  rclcpp::sleep_for(std::chrono::milliseconds(10));
+  rclcpp::spin_some(node);
+
+  auto topics = rqt_image_overlay::ListImageTopics(*node);
+  ASSERT_TRUE(topics.empty());
+}


### PR DESCRIPTION
Handle:
* fake transports that end with a transport ending, but aren't actually image topics
* topics that were discovered, but don't have any publishers. This happens if something else also already had a subscription on the topic.

It makes sense to list image topics without any publishers in the Image Topic list. 

Achieved by creating a subscription, and see if there are any publishers registered. If there are no publishers, then ignore it.

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>