### PR TITLE
Replace ambiguous python shebangs

### DIFF
--- a/rqt_image_overlay/scripts/rqt_image_overlay
+++ b/rqt_image_overlay/scripts/rqt_image_overlay
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/rqt_image_overlay/setup.py
+++ b/rqt_image_overlay/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 


### PR DESCRIPTION
ROS 2 exclusively uses Python 3. It would be best to specifically use a Python 3 interpreter to avoid getting invoked with an unsupported Python 2 interpreter.

Should resolve RPM build errors on RHEL like this one: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__rqt_image_overlay__rhel_8_x86_64__binary/41/