### PR TITLE
change theora transport dependency to compressed transport

### DIFF
--- a/rqt_image_overlay/package.xml
+++ b/rqt_image_overlay/package.xml
@@ -20,7 +20,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>theora_image_transport</test_depend>
+  <test_depend>compressed_image_transport</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/rqt_image_overlay/test/CMakeLists.txt
+++ b/rqt_image_overlay/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Build test_list_image_topics
 find_package(rclcpp REQUIRED)
-find_package(theora_image_transport REQUIRED)
+find_package(compressed_image_transport REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 ament_add_gtest(test_list_image_topics
   test_list_image_topics.cpp)
@@ -12,8 +13,9 @@ target_link_libraries(test_list_image_topics
 
 ament_target_dependencies(test_list_image_topics
   rclcpp
-  theora_image_transport
-  std_msgs)
+  compressed_image_transport
+  std_msgs
+  sensor_msgs)
 
 # Build test_msg_storage
 ament_add_gtest(test_msg_storage

--- a/rqt_image_overlay/test/test_list_image_topics.cpp
+++ b/rqt_image_overlay/test/test_list_image_topics.cpp
@@ -19,11 +19,11 @@
 #include "rclcpp/node.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "image_transport/image_transport.hpp"
-#include "theora_image_transport/msg/packet.hpp"
+#include "sensor_msgs/msg/compressed_image.hpp"
 #include "std_msgs/msg/string.hpp"
 
-// In this test, there's two types of transports (ie. "raw" and "theora") available.
-// The "theora" transport is declared as a test dependency so we can write tests for
+// In this test, there's two types of transports (ie. "raw" and "compressed") available.
+// The "compressed" transport is declared as a test dependency so we can write tests for
 // image_transport plugins.
 class TestListImageTopics : public ::testing::Test
 {
@@ -71,7 +71,7 @@ TEST_F(TestListImageTopics, TestOne)
   auto imageTopics = rqt_image_overlay::ListImageTopics(*node);
   ASSERT_EQ(imageTopics.size(), 2u);
   EXPECT_TRUE(checkContains(imageTopics, rqt_image_overlay::ImageTopic{"/test_topic", "raw"}));
-  EXPECT_TRUE(checkContains(imageTopics, rqt_image_overlay::ImageTopic{"/test_topic", "theora"}));
+  EXPECT_TRUE(checkContains(imageTopics, rqt_image_overlay::ImageTopic{"/test_topic", "compressed"}));
 }
 
 TEST_F(TestListImageTopics, TestThree)
@@ -95,7 +95,7 @@ TEST_F(TestListImageTopics, TestThree)
   EXPECT_TRUE(
     checkContains(
       imageTopics,
-      rqt_image_overlay::ImageTopic{"/test_ns1/test_topic1", "theora"}));
+      rqt_image_overlay::ImageTopic{"/test_ns1/test_topic1", "compressed"}));
   EXPECT_TRUE(
     checkContains(
       imageTopics,
@@ -103,7 +103,7 @@ TEST_F(TestListImageTopics, TestThree)
   EXPECT_TRUE(
     checkContains(
       imageTopics,
-      rqt_image_overlay::ImageTopic{"/test_ns2/test_topic2", "theora"}));
+      rqt_image_overlay::ImageTopic{"/test_ns2/test_topic2", "compressed"}));
   EXPECT_TRUE(
     checkContains(
       imageTopics,
@@ -111,15 +111,15 @@ TEST_F(TestListImageTopics, TestThree)
   EXPECT_TRUE(
     checkContains(
       imageTopics,
-      rqt_image_overlay::ImageTopic{"/test_ns3/test_topic3", "theora"}));
+      rqt_image_overlay::ImageTopic{"/test_ns3/test_topic3", "compressed"}));
 }
 
-TEST_F(TestListImageTopics, TestOnlyTheoraTransport)
+TEST_F(TestListImageTopics, TestOnlyCompressedTransport)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
 
   auto publisher =
-    node->create_publisher<theora_image_transport::msg::Packet>("/test_topic/theora", 1);
+    node->create_publisher<sensor_msgs::msg::CompressedImage>("/test_topic/compressed", 1);
 
   // Give a chance for the topic to be picked up
   rclcpp::sleep_for(std::chrono::milliseconds(10));
@@ -130,17 +130,17 @@ TEST_F(TestListImageTopics, TestOnlyTheoraTransport)
   EXPECT_TRUE(
     checkContains(
       imageTopics,
-      rqt_image_overlay::ImageTopic{"/test_topic", "theora"}));
+      rqt_image_overlay::ImageTopic{"/test_topic", "compressed"}));
 }
 
-TEST_F(TestListImageTopics, TestFakeTheoraTransport)
+TEST_F(TestListImageTopics, TestFakeCompressedTransport)
 {
   // In this example, we test a case where the topic name ends with a transport type, but the msg
-  // type is not theora_image_transport::msg::Packet.
+  // type is not sensor_msgs::msg::CompressedImage.
   auto node = std::make_shared<rclcpp::Node>("test_node");
 
   auto publisher =
-    node->create_publisher<std_msgs::msg::String>("/test_topic/theora", 1);
+    node->create_publisher<std_msgs::msg::String>("/test_topic/compressed", 1);
 
   // Give a chance for the topic to be picked up
   rclcpp::sleep_for(std::chrono::milliseconds(10));

--- a/rqt_image_overlay/test/test_list_image_topics.cpp
+++ b/rqt_image_overlay/test/test_list_image_topics.cpp
@@ -71,7 +71,8 @@ TEST_F(TestListImageTopics, TestOne)
   auto imageTopics = rqt_image_overlay::ListImageTopics(*node);
   ASSERT_EQ(imageTopics.size(), 2u);
   EXPECT_TRUE(checkContains(imageTopics, rqt_image_overlay::ImageTopic{"/test_topic", "raw"}));
-  EXPECT_TRUE(checkContains(imageTopics, rqt_image_overlay::ImageTopic{"/test_topic", "compressed"}));
+  EXPECT_TRUE(
+    checkContains(imageTopics, rqt_image_overlay::ImageTopic{"/test_topic", "compressed"}));
 }
 
 TEST_F(TestListImageTopics, TestThree)


### PR DESCRIPTION
Theora image transport seems to be not that well maintained in comparison with compressed transport.
Hopefully this fixes https://github.com/ros-sports/rqt_image_overlay/issues/20 too.

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>