### PR TITLE
Add dialog that lets you select display options for depth images

### DIFF
--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -2,7 +2,7 @@
 
 name: Build and Test (rolling)
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push
   push:
@@ -26,9 +26,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - uses: actions/checkout@v2
       - uses: ros-tooling/setup-ros@v0.3
         with:
           use-ros2-testing: true
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: rolling
+          vcs-repo-file-url: dependencies.repos

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,0 +1,5 @@
+repositories:
+  ros_image_to_qimage:
+    type: git
+    url: https://github.com/ros-sports/ros_image_to_qimage.git
+    version: ijnek-cvtcolorfordisplayoptions

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,5 +1,5 @@
 repositories:
   ros_image_to_qimage:
     type: git
-    url: https://github.com/ros-sports/ros_image_to_qimage.git
+    url: https://github.com/ijnek/ros_image_to_qimage.git
     version: ijnek-cvtcolorfordisplayoptions

--- a/rqt_image_overlay/CMakeLists.txt
+++ b/rqt_image_overlay/CMakeLists.txt
@@ -36,7 +36,9 @@ qt5_wrap_cpp(SOURCES    # Must do this for qt's Meta-Object Compiler.
   src/image_manager.hpp
   src/color_dialog_delegate.hpp
   src/overlay_manager_view.hpp)
-qt5_wrap_ui(UIS resource/image_overlay.ui)
+qt5_wrap_ui(UIS
+  resource/image_overlay.ui
+  resource/depth_image_display_options_dialog.ui)
 add_library(rqt_image_overlay SHARED
   ${SOURCES}
   ${UIS})

--- a/rqt_image_overlay/resource/depth_image_display_options_dialog.ui
+++ b/rqt_image_overlay/resource/depth_image_display_options_dialog.ui
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DepthImageDisplayOptionsDialog</class>
+ <widget class="QDialog" name="DepthImageDisplayOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>298</width>
+    <height>203</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Depth Image Display Options</string>
+  </property>
+  <property name="toolTip">
+   <string>Depth Image Display Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="dynamic_scaling_label">
+       <property name="text">
+        <string>Dynamic Scaling</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="dynamic_scaling_check_box">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="minimum_value_label">
+       <property name="text">
+        <string>Minimum Value</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="minimum_value_spin_box">
+       <property name="decimals">
+        <number>4</number>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="maximum_value_label">
+       <property name="text">
+        <string>Maximum Value</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="maximum_value_spin_box">
+       <property name="decimals">
+        <number>4</number>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="colormap_label">
+       <property name="text">
+        <string>Colormap</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QSpinBox" name="colormap_spin_box">
+       <property name="minimum">
+        <number>-1</number>
+       </property>
+       <property name="maximum">
+        <number>99</number>
+       </property>
+       <property name="value">
+        <number>-1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="background_label">
+       <property name="text">
+        <string>Background Label</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="background_label_spin_box">
+       <property name="minimum">
+        <number>-1</number>
+       </property>
+       <property name="value">
+        <number>-1</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DepthImageDisplayOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DepthImageDisplayOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/rqt_image_overlay/resource/image_overlay.ui
+++ b/rqt_image_overlay/resource/image_overlay.ui
@@ -35,6 +35,23 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="depth_image_display_options_button">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Depth Image Display Options</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset theme="preferences-system">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/rqt_image_overlay/src/image_manager.cpp
+++ b/rqt_image_overlay/src/image_manager.cpp
@@ -28,6 +28,9 @@ namespace rqt_image_overlay
 ImageManager::ImageManager(const std::shared_ptr<rclcpp::Node> & node)
 : node(node)
 {
+  // Set initial depthImageDisplayOptions
+  depthImageDisplayOptions = std::make_shared<cv_bridge::CvtColorForDisplayOptions>();
+  depthImageDisplayOptions->max_image_value = 10.0;
 }
 
 void ImageManager::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
@@ -85,13 +88,11 @@ void ImageManager::updateDepthImageDisplayOptions()
   // Place current settings into Dialog
   const std::shared_ptr<cv_bridge::CvtColorForDisplayOptions> options(
     std::atomic_load(&depthImageDisplayOptions));
-  if (options) {
-    ui->dynamic_scaling_check_box->setChecked(options->do_dynamic_scaling);
-    ui->minimum_value_spin_box->setValue(options->min_image_value);
-    ui->maximum_value_spin_box->setValue(options->max_image_value);
-    ui->colormap_spin_box->setValue(options->colormap);
-    ui->background_label_spin_box->setValue(options->bg_label);
-  }
+  ui->dynamic_scaling_check_box->setChecked(options->do_dynamic_scaling);
+  ui->minimum_value_spin_box->setValue(options->min_image_value);
+  ui->maximum_value_spin_box->setValue(options->max_image_value);
+  ui->colormap_spin_box->setValue(options->colormap);
+  ui->background_label_spin_box->setValue(options->bg_label);
 
   if (dialog->exec() == QDialog::Accepted) {
     auto newOptions = std::make_shared<cv_bridge::CvtColorForDisplayOptions>();

--- a/rqt_image_overlay/src/image_manager.cpp
+++ b/rqt_image_overlay/src/image_manager.cpp
@@ -94,7 +94,7 @@ void ImageManager::updateDepthImageDisplayOptions()
   }
 
   if (dialog->exec() == QDialog::Accepted) {
-    std::shared_ptr<cv_bridge::CvtColorForDisplayOptions> newOptions;
+    auto newOptions = std::make_shared<cv_bridge::CvtColorForDisplayOptions>();
     newOptions->do_dynamic_scaling = ui->dynamic_scaling_check_box->isChecked();
     newOptions->min_image_value = ui->minimum_value_spin_box->value();
     newOptions->max_image_value = ui->maximum_value_spin_box->value();
@@ -129,7 +129,7 @@ std::tuple<std::shared_ptr<QImage>, rclcpp::Time> ImageManager::getClosestImageA
   auto closestTime = msgStorage.getClosestTime(targetTimeReceived);
   auto msg = msgStorage.getMsg(closestTime);
   auto image = std::make_shared<QImage>(
-    ros_image_to_qimage::Convert(*msg), *std::atomic_load(&depthImageDisplayOptions));
+    ros_image_to_qimage::Convert(*msg, *std::atomic_load(&depthImageDisplayOptions)));
   return std::make_tuple(image, rclcpp::Time{msg->header.stamp});
 }
 

--- a/rqt_image_overlay/src/image_manager.hpp
+++ b/rqt_image_overlay/src/image_manager.hpp
@@ -26,6 +26,7 @@
 #include "msg_storage.hpp"
 #include "overlay_time_info.hpp"
 
+namespace cv_bridge {struct CvtColorForDisplayOptions;}
 namespace rclcpp {class Node;}
 
 namespace rqt_image_overlay
@@ -54,6 +55,7 @@ protected:
 public slots:
   void onTopicChanged(int index);
   void updateImageTopicList();
+  void updateDepthImageDisplayOptions();
 
 private:
   void callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & msg);
@@ -64,6 +66,7 @@ private:
   rclcpp::Clock systemClock{RCL_SYSTEM_TIME};
 
   std::vector<ImageTopic> imageTopics;
+  std::shared_ptr<cv_bridge::CvtColorForDisplayOptions> depthImageDisplayOptions;
 };
 
 }  // namespace rqt_image_overlay

--- a/rqt_image_overlay/src/image_manager.hpp
+++ b/rqt_image_overlay/src/image_manager.hpp
@@ -27,6 +27,7 @@
 #include "overlay_time_info.hpp"
 
 namespace cv_bridge {struct CvtColorForDisplayOptions;}
+namespace qt_gui_cpp {class Settings;}
 namespace rclcpp {class Node;}
 
 namespace rqt_image_overlay
@@ -47,6 +48,9 @@ public:
 
   std::optional<ImageTopic> getImageTopic(unsigned index);
   void addImageTopicExplicitly(ImageTopic imageTopic);
+
+  void saveSettings(qt_gui_cpp::Settings & settings) const;
+  void restoreSettings(const qt_gui_cpp::Settings & settings);
 
 protected:
   int rowCount(const QModelIndex & parent = QModelIndex()) const override;

--- a/rqt_image_overlay/src/image_overlay.cpp
+++ b/rqt_image_overlay/src/image_overlay.cpp
@@ -58,6 +58,10 @@ void ImageOverlay::initPlugin(qt_gui_cpp::PluginContext & context)
     ui->refresh_image_topics_button, SIGNAL(pressed()), imageManager.get(),
     SLOT(updateImageTopicList()));
 
+  connect(
+    ui->depth_image_display_options_button, SIGNAL(pressed()), imageManager.get(),
+    SLOT(updateDepthImageDisplayOptions()));
+
   connect(ui->remove_overlay_button, SIGNAL(pressed()), this, SLOT(removeOverlay()));
 
   compositor->setCallableSetImage(

--- a/rqt_image_overlay/src/image_overlay.cpp
+++ b/rqt_image_overlay/src/image_overlay.cpp
@@ -95,6 +95,8 @@ void ImageOverlay::saveSettings(
   qt_gui_cpp::Settings &,
   qt_gui_cpp::Settings & instance_settings) const
 {
+  imageManager->saveSettings(instance_settings);
+
   auto optionalImageTopic = imageManager->getImageTopic(ui->image_topics_combo_box->currentIndex());
   if (optionalImageTopic.has_value()) {
     auto imageTopic = optionalImageTopic.value();
@@ -109,6 +111,8 @@ void ImageOverlay::restoreSettings(
   const qt_gui_cpp::Settings &,
   const qt_gui_cpp::Settings & instance_settings)
 {
+  imageManager->restoreSettings(instance_settings);
+
   if (instance_settings.contains("image_topic") && instance_settings.contains("image_transport")) {
     std::string topic = instance_settings.value("image_topic").toString().toStdString();
     std::string transport = instance_settings.value("image_transport").toString().toStdString();


### PR DESCRIPTION
Resolves: #37

Still left to:
- [ ] disable display options button if select image topic is not single channel
- [ ] disable min and max spin box if dynamic value is selected
- [ ] use a selection drop-down box for "colormap" rather than a spinbox
- [x] save and load options 