### PR TITLE
Add configuration dialog and wait window setting

### DIFF
--- a/rqt_image_overlay/CMakeLists.txt
+++ b/rqt_image_overlay/CMakeLists.txt
@@ -36,7 +36,7 @@ qt5_wrap_cpp(SOURCES    # Must do this for qt's Meta-Object Compiler.
   src/image_manager.hpp
   src/color_dialog_delegate.hpp
   src/overlay_manager_view.hpp)
-qt5_wrap_ui(UIS resource/image_overlay.ui)
+qt5_wrap_ui(UIS resource/image_overlay.ui resource/configuration_dialog.ui)
 add_library(rqt_image_overlay SHARED
   ${SOURCES}
   ${UIS})

--- a/rqt_image_overlay/resource/configuration_dialog.ui
+++ b/rqt_image_overlay/resource/configuration_dialog.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+  <class>ConfigurationDialog</class>
+  <widget class="QDialog" name="configuration_dialog">
+    <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+      </sizepolicy>
+    </property>
+    <property name="windowTitle">
+      <string>Image Overlay configuration</string>
+    </property>
+    <layout class="QVBoxLayout" name="window_layout">
+      <item>
+        <layout class="QFormLayout" name="input_layout">
+          <item row="0" column="0">
+            <widget class="QLabel" name="windowLabel">
+              <property name="text">
+                <string>Waiting &amp;window (sec)</string>
+              </property>
+              <property name="toolTip">
+                <string>Time to wait before composing an image. If overlay messages arrive much later than the image, increase this value.</string>
+              </property>
+              <property name="buddy">
+                <cstring>window</cstring>
+              </property>
+            </widget>
+          </item>
+          <item row="0" column="1">
+            <widget class="QDoubleSpinBox" name="window">
+              <property name="decimals">
+                <number>3</number>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
+      <item>
+        <widget class="QDialogButtonBox" name="dialog_button_box">
+          <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="standardButtons">
+            <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+          </property>
+        </widget>
+      </item>
+    </layout>
+  </widget>
+  <resources/>
+  <connections>
+    <connection>
+      <sender>dialog_button_box</sender>
+      <signal>accepted()</signal>
+      <receiver>configuration_dialog</receiver>
+      <slot>accept()</slot>
+    </connection>
+    <connection>
+      <sender>dialog_button_box</sender>
+      <signal>rejected()</signal>
+      <receiver>configuration_dialog</receiver>
+      <slot>reject()</slot>
+    </connection>
+  </connections>
+</ui>

--- a/rqt_image_overlay/src/compositor.cpp
+++ b/rqt_image_overlay/src/compositor.cpp
@@ -22,19 +22,22 @@ namespace rqt_image_overlay
 {
 
 Compositor::Compositor(
-  const ImageManager & imageManager, const OverlayManager & overlayManager,
-  float frequency, rclcpp::Duration window)
-: imageManager(imageManager), overlayManager(overlayManager), window_(window)
+  const ImageManager & imageManager, const OverlayManager & overlayManager, float frequency)
+: imageManager(imageManager), overlayManager(overlayManager),
+  window_(std::make_shared<rclcpp::Duration>(0, 300000000))
 {
   startTimer(1000.0 / frequency);
 }
 
-void Compositor::setWindow(rclcpp::Duration window) {
-  window_ = window;
+void Compositor::setWindow(const rclcpp::Duration & window)
+{
+  std::atomic_store(&window_, std::make_shared<rclcpp::Duration>(window));
 }
 
-rclcpp::Duration Compositor::window() const {
-  return window_;
+rclcpp::Duration Compositor::getWindow() const
+{
+  auto window = std::atomic_load(&window_);
+  return *window;
 }
 
 void Compositor::setCallableSetImage(std::function<void(std::shared_ptr<QImage>)> setImage)
@@ -48,7 +51,10 @@ std::shared_ptr<QImage> Compositor::compose()
     return nullptr;
   }
 
-  rclcpp::Time targetTime = systemClock.now() - window_;
+  // Get window_ value through the getWindow() method so that it is thread-safe
+  auto window = getWindow();
+
+  rclcpp::Time targetTime = systemClock.now() - window;
   auto [composition, imageHeaderTime] = imageManager.getClosestImageAndHeaderTime(targetTime);
   OverlayTimeInfo overlayTimeInfo{targetTime, imageHeaderTime};
   overlayManager.overlay(*composition, overlayTimeInfo);

--- a/rqt_image_overlay/src/compositor.cpp
+++ b/rqt_image_overlay/src/compositor.cpp
@@ -24,9 +24,17 @@ namespace rqt_image_overlay
 Compositor::Compositor(
   const ImageManager & imageManager, const OverlayManager & overlayManager,
   float frequency, rclcpp::Duration window)
-: imageManager(imageManager), overlayManager(overlayManager), window(window)
+: imageManager(imageManager), overlayManager(overlayManager), window_(window)
 {
   startTimer(1000.0 / frequency);
+}
+
+void Compositor::setWindow(rclcpp::Duration window) {
+  window_ = window;
+}
+
+rclcpp::Duration Compositor::window() const {
+  return window_;
 }
 
 void Compositor::setCallableSetImage(std::function<void(std::shared_ptr<QImage>)> setImage)
@@ -40,7 +48,7 @@ std::shared_ptr<QImage> Compositor::compose()
     return nullptr;
   }
 
-  rclcpp::Time targetTime = systemClock.now() - window;
+  rclcpp::Time targetTime = systemClock.now() - window_;
   auto [composition, imageHeaderTime] = imageManager.getClosestImageAndHeaderTime(targetTime);
   OverlayTimeInfo overlayTimeInfo{targetTime, imageHeaderTime};
   overlayManager.overlay(*composition, overlayTimeInfo);

--- a/rqt_image_overlay/src/compositor.hpp
+++ b/rqt_image_overlay/src/compositor.hpp
@@ -35,6 +35,10 @@ public:
     const ImageManager & imageManager, const OverlayManager & overlayManager,
     float frequency, rclcpp::Duration window = rclcpp::Duration{0, 300000000});
 
+  void setWindow(rclcpp::Duration window);
+
+  rclcpp::Duration window() const;
+
   void setCallableSetImage(std::function<void(std::shared_ptr<QImage>)> setImage);
 
 private:
@@ -46,7 +50,7 @@ private:
 
   std::function<void(std::shared_ptr<QImage>)> setImage;
 
-  const rclcpp::Duration window;  // Wait window for collecting messages before composing image
+  rclcpp::Duration window_;  // Wait window for collecting messages before composing image
   rclcpp::Clock systemClock{RCL_SYSTEM_TIME};
 };
 

--- a/rqt_image_overlay/src/compositor.hpp
+++ b/rqt_image_overlay/src/compositor.hpp
@@ -32,12 +32,11 @@ class Compositor : public QObject
 
 public:
   Compositor(
-    const ImageManager & imageManager, const OverlayManager & overlayManager,
-    float frequency, rclcpp::Duration window = rclcpp::Duration{0, 300000000});
+    const ImageManager & imageManager, const OverlayManager & overlayManager, float frequency);
 
-  void setWindow(rclcpp::Duration window);
-
-  rclcpp::Duration window() const;
+  // Thread safe setter/getter for window
+  void setWindow(const rclcpp::Duration & window);
+  rclcpp::Duration getWindow() const;
 
   void setCallableSetImage(std::function<void(std::shared_ptr<QImage>)> setImage);
 
@@ -50,7 +49,11 @@ private:
 
   std::function<void(std::shared_ptr<QImage>)> setImage;
 
-  rclcpp::Duration window_;  // Wait window for collecting messages before composing image
+  // Wait window for collecting messages before composing image.
+  // To access this value, use the getWindow() method to ensure thread-safety, even from within
+  // this class.
+  std::shared_ptr<rclcpp::Duration> window_;
+
   rclcpp::Clock systemClock{RCL_SYSTEM_TIME};
 };
 

--- a/rqt_image_overlay/src/image_overlay.cpp
+++ b/rqt_image_overlay/src/image_overlay.cpp
@@ -36,7 +36,6 @@ ImageOverlay::~ImageOverlay() = default;
 void ImageOverlay::initPlugin(qt_gui_cpp::PluginContext & context)
 {
   ui = std::make_unique<Ui::ImageOverlay>();
-  ui_configuration_dialog = std::make_unique<Ui::ConfigurationDialog>();
   menu = std::make_unique<QMenu>();
   imageManager = std::make_shared<ImageManager>(node_);
   overlayManager = std::make_shared<OverlayManager>(node_);
@@ -99,8 +98,7 @@ void ImageOverlay::saveSettings(
     instance_settings.setValue("image_topic", QString::fromStdString(imageTopic.topic));
     instance_settings.setValue("image_transport", QString::fromStdString(imageTopic.transport));
   }
-  instance_settings.setValue("window", compositor->window().seconds());
-
+  instance_settings.setValue("compositor_window", compositor->getWindow().seconds());
   overlayManager->saveSettings(instance_settings);
 }
 
@@ -114,16 +112,11 @@ void ImageOverlay::restoreSettings(
     imageManager->addImageTopicExplicitly(ImageTopic{topic, transport});
     ui->image_topics_combo_box->setCurrentIndex(1);
   }
-  auto window_setting = instance_settings.value("window");
-  if (!window_setting.isNull()) {
-    auto window_string = window_setting.toString().toStdString();
-    char * err;
-    double window = std::strtod(window_string.c_str(), &err);
-    if (err == window_string.c_str()) {
-      // double conversion error
-    } else {
-      compositor->setWindow(rclcpp::Duration::from_seconds(window));
-    }
+
+  if (instance_settings.contains("compositor_window")) {
+    auto window_double = instance_settings.value("compositor_window").toDouble();
+    auto duration = rclcpp::Duration::from_seconds(window_double);
+    compositor->setWindow(duration);
   }
   overlayManager->restoreSettings(instance_settings);
 }
@@ -152,22 +145,15 @@ bool ImageOverlay::hasConfiguration() const
 
 void ImageOverlay::triggerConfiguration()
 {
-  if (configuration_dialog) {
-    return;
+  QDialog * configuration_dialog = new QDialog();
+  auto ui_configuration_dialog = std::make_unique<Ui::ConfigurationDialog>();
+  ui_configuration_dialog->setupUi(configuration_dialog);
+  ui_configuration_dialog->window->setValue(compositor->getWindow().seconds());
+
+  if (configuration_dialog->exec() == QDialog::Accepted) {
+    auto window_seconds = ui_configuration_dialog->window->value();
+    compositor->setWindow(rclcpp::Duration::from_seconds(window_seconds));
   }
-  configuration_dialog = std::make_unique<QDialog>();
-  configuration_dialog->setAttribute(Qt::WA_DeleteOnClose);
-  ui_configuration_dialog->setupUi(configuration_dialog.get());
-  ui_configuration_dialog->window->setValue(compositor->window().seconds());
-  auto connection = connect(
-    configuration_dialog.get(), &QDialog::finished, [this](int result) {
-      if (result == QDialog::Accepted) {
-        auto window_seconds = ui_configuration_dialog->window->value();
-        compositor->setWindow(rclcpp::Duration::from_seconds(window_seconds));
-      }
-      configuration_dialog.reset();
-    });
-  configuration_dialog->open();
 }
 
 

--- a/rqt_image_overlay/src/image_overlay.cpp
+++ b/rqt_image_overlay/src/image_overlay.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <memory>
 #include "./ui_image_overlay.h"
+#include "./ui_configuration_dialog.h"
 #include "image_overlay.hpp"
 #include "compositor.hpp"
 #include "overlay_manager.hpp"
@@ -35,6 +36,7 @@ ImageOverlay::~ImageOverlay() = default;
 void ImageOverlay::initPlugin(qt_gui_cpp::PluginContext & context)
 {
   ui = std::make_unique<Ui::ImageOverlay>();
+  ui_configuration_dialog = std::make_unique<Ui::ConfigurationDialog>();
   menu = std::make_unique<QMenu>();
   imageManager = std::make_shared<ImageManager>(node_);
   overlayManager = std::make_shared<OverlayManager>(node_);
@@ -97,6 +99,7 @@ void ImageOverlay::saveSettings(
     instance_settings.setValue("image_topic", QString::fromStdString(imageTopic.topic));
     instance_settings.setValue("image_transport", QString::fromStdString(imageTopic.transport));
   }
+  instance_settings.setValue("window", compositor->window().seconds());
 
   overlayManager->saveSettings(instance_settings);
 }
@@ -111,7 +114,17 @@ void ImageOverlay::restoreSettings(
     imageManager->addImageTopicExplicitly(ImageTopic{topic, transport});
     ui->image_topics_combo_box->setCurrentIndex(1);
   }
-
+  auto window_setting = instance_settings.value("window");
+  if (!window_setting.isNull()) {
+    auto window_string = window_setting.toString().toStdString();
+    char * err;
+    double window = std::strtod(window_string.c_str(), &err);
+    if (err == window_string.c_str()) {
+      // double conversion error
+    } else {
+      compositor->setWindow(rclcpp::Duration::from_seconds(window));
+    }
+  }
   overlayManager->restoreSettings(instance_settings);
 }
 
@@ -130,6 +143,31 @@ void ImageOverlay::fillOverlayMenu()
   }
 
   ui->add_overlay_button->setMenu(menu.get());
+}
+
+bool ImageOverlay::hasConfiguration() const
+{
+  return true;
+}
+
+void ImageOverlay::triggerConfiguration()
+{
+  if (configuration_dialog) {
+    return;
+  }
+  configuration_dialog = std::make_unique<QDialog>();
+  configuration_dialog->setAttribute(Qt::WA_DeleteOnClose);
+  ui_configuration_dialog->setupUi(configuration_dialog.get());
+  ui_configuration_dialog->window->setValue(compositor->window().seconds());
+  auto connection = connect(
+    configuration_dialog.get(), &QDialog::finished, [this](int result) {
+      if (result == QDialog::Accepted) {
+        auto window_seconds = ui_configuration_dialog->window->value();
+        compositor->setWindow(rclcpp::Duration::from_seconds(window_seconds));
+      }
+      configuration_dialog.reset();
+    });
+  configuration_dialog->open();
 }
 
 

--- a/rqt_image_overlay/src/image_overlay.cpp
+++ b/rqt_image_overlay/src/image_overlay.cpp
@@ -145,9 +145,9 @@ bool ImageOverlay::hasConfiguration() const
 
 void ImageOverlay::triggerConfiguration()
 {
-  QDialog * configuration_dialog = new QDialog();
+  auto configuration_dialog = std::make_unique<QDialog>();
   auto ui_configuration_dialog = std::make_unique<Ui::ConfigurationDialog>();
-  ui_configuration_dialog->setupUi(configuration_dialog);
+  ui_configuration_dialog->setupUi(configuration_dialog.get());
   ui_configuration_dialog->window->setValue(compositor->getWindow().seconds());
 
   if (configuration_dialog->exec() == QDialog::Accepted) {

--- a/rqt_image_overlay/src/image_overlay.hpp
+++ b/rqt_image_overlay/src/image_overlay.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include "rqt_gui_cpp/plugin.h"
 
-namespace Ui {class ImageOverlay;}
+namespace Ui {class ImageOverlay;class ConfigurationDialog;}
 namespace rqt_image_overlay
 {
 class ImageManager;
@@ -42,6 +42,8 @@ public:
   void restoreSettings(
     const qt_gui_cpp::Settings &,
     const qt_gui_cpp::Settings & instanceSettings) override;
+  bool hasConfiguration() const override;
+  void triggerConfiguration() override;
 
 public slots:
   void removeOverlay();
@@ -50,10 +52,12 @@ private:
   void fillOverlayMenu();
 
   std::unique_ptr<Ui::ImageOverlay> ui;
+  std::unique_ptr<Ui::ConfigurationDialog> ui_configuration_dialog;
   std::unique_ptr<QMenu> menu;
   std::shared_ptr<ImageManager> imageManager;
   std::shared_ptr<OverlayManager> overlayManager;
   std::unique_ptr<Compositor> compositor;
+  std::unique_ptr<QDialog> configuration_dialog;
 };
 
 }  // namespace rqt_image_overlay

--- a/rqt_image_overlay/src/image_overlay.hpp
+++ b/rqt_image_overlay/src/image_overlay.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include "rqt_gui_cpp/plugin.h"
 
-namespace Ui {class ImageOverlay;class ConfigurationDialog;}
+namespace Ui {class ImageOverlay;}
 namespace rqt_image_overlay
 {
 class ImageManager;
@@ -52,12 +52,10 @@ private:
   void fillOverlayMenu();
 
   std::unique_ptr<Ui::ImageOverlay> ui;
-  std::unique_ptr<Ui::ConfigurationDialog> ui_configuration_dialog;
   std::unique_ptr<QMenu> menu;
   std::shared_ptr<ImageManager> imageManager;
   std::shared_ptr<OverlayManager> overlayManager;
   std::unique_ptr<Compositor> compositor;
-  std::unique_ptr<QDialog> configuration_dialog;
 };
 
 }  // namespace rqt_image_overlay


### PR DESCRIPTION
Adds a configuration dialog to set the composition waiting time.
300ms is a good default, but I have had to deal with higher latencies in overlay messages.
Adjusting the waiting time without rebuilding has been convenient.

![rqt_image_overlay-waiting_time_cfg](https://user-images.githubusercontent.com/5438458/185602482-8139a470-da41-4628-ae5e-0530654c3722.png)

