### PR TITLE
Correctly map ImageManager list model index to topic vector

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   vision_opencv:
     type: git
     url: https://github.com/ros-perception/vision_opencv.git
-    version: ros2
+    version: rolling
   ros_image_to_qimage:
     type: git
     url: https://github.com/ros-sports/ros_image_to_qimage.git

--- a/rqt_image_overlay/src/image_manager.cpp
+++ b/rqt_image_overlay/src/image_manager.cpp
@@ -141,9 +141,12 @@ bool ImageManager::imageAvailable() const
 
 std::optional<ImageTopic> ImageManager::getImageTopic(unsigned index)
 {
-  if (index > 0 && index < imageTopics.size()) {
-    const ImageTopic & it = imageTopics.at(index);
-    return std::make_optional<ImageTopic>(it);
+  if (index > 0) {
+    auto topic_index = index - 1;
+    if (topic_index < imageTopics.size()) {
+      const ImageTopic & it = imageTopics.at(topic_index);
+      return std::make_optional<ImageTopic>(it);
+    }
   }
   return std::nullopt;
 }

--- a/rqt_image_overlay/src/image_manager.cpp
+++ b/rqt_image_overlay/src/image_manager.cpp
@@ -154,7 +154,6 @@ std::optional<ImageTopic> ImageManager::getImageTopic(unsigned index)
 void ImageManager::addImageTopicExplicitly(ImageTopic imageTopic)
 {
   beginResetModel();
-  imageTopics.clear();
   imageTopics.push_back(imageTopic);
   endResetModel();
 }

--- a/rqt_image_overlay/test/test_image_manager.cpp
+++ b/rqt_image_overlay/test/test_image_manager.cpp
@@ -94,3 +94,18 @@ TEST_F(TestImageManager, getHeaderTime)
   EXPECT_EQ(headerTime, time);
   EXPECT_NE(image, nullptr);
 }
+
+TEST_F(TestImageManager, TestGetImageTopic)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  rqt_image_overlay::ImageManager imageManager{node};
+
+  auto imageTopic1 = rqt_image_overlay::ImageTopic{"topic_1", "raw"};
+  imageManager.addImageTopicExplicitly(imageTopic1);
+  auto imageTopic2 = rqt_image_overlay::ImageTopic{"topic_2", "raw"};
+  imageManager.addImageTopicExplicitly(imageTopic2);
+
+  EXPECT_EQ(imageManager.getImageTopic(0), std::nullopt);
+  EXPECT_EQ(imageManager.getImageTopic(1).value(), imageTopic1);
+  EXPECT_EQ(imageManager.getImageTopic(2).value(), imageTopic2);
+}


### PR DESCRIPTION
Most functions of ImageManager interpret index 0 as _unselected_ and map indices > 0 to the actual topics.
This PR does the same in getImageTopic.

Fixes #45