### PR TITLE
Add rqt_gui to package.xml

### DIFF
--- a/rqt_image_overlay/package.xml
+++ b/rqt_image_overlay/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>pluginlib</depend>
+  <depend>rqt_gui</depend>
   <depend>rqt_gui_cpp</depend>
   <depend>image_transport</depend>
   <depend>qtbase5-dev</depend>


### PR DESCRIPTION
Without this, the following error arises:

```sh
Traceback (most recent call last):
  File "/opt/ros/rolling/lib/rqt_image_overlay/rqt_image_overlay", line 5, in <module>
    from rqt_gui.main import Main
ModuleNotFoundError: No module named 'rqt_gui'
```